### PR TITLE
Get np.linspace() out of the for loop

### DIFF
--- a/envelop.py
+++ b/envelop.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -20,14 +21,15 @@ def subplots():
         ax.spines[spine].set_position('zero')
     for spine in ['right', 'top']:
         ax.spines[spine].set_color('none')
-    
+
     return (fig, ax)
 
 
 fig, ax = subplots()
+x = np.linspace(-5, 5, 200)
+
 for a in range(-z/2 + 1, z/2 + 1):
-   x = np.linspace(-5, 5, 200)
-   y = f(x, t=a)
-   ax.plot(x, y, 'b-', linewidth=2)
-   ax.legend(loc='lower right')
+    y = f(x, t=a)
+    ax.plot(x, y, 'b-', linewidth=2)
+
 plt.show()


### PR DESCRIPTION
よくできました．

1.
x = np.linspace(...) は a によらないので，
for ループの中で何度も代入をさせる必要はないです．

2.
ax.legend(...) のところでエラーが出ているので消します．

3.
(ipython では大丈夫でしたが) ふつうの python では日本語でエラーが出ました．
ファイルの先頭におまじない # -_\- coding: utf-8 -_\- を入れました．

4.
"z =11" みたいに，ほかの定数も変数で置き換えて一カ所にまとめておくとよいでしょう．
